### PR TITLE
Changes Required for the seL4 Capabilities Tutorial to Function

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -66,25 +66,6 @@ pub mod sel4_config {\n",
         self.writer
             .write_all(BOOT_INFO_AND_LANG_ITEM_CODE.as_bytes())?;
 
-        self.writer.write_all(
-            b"
-fn get_untyped(info: &seL4_BootInfo, size_bytes: usize) -> Option<seL4_CPtr> {
-    let mut idx = 0;
-    for i in info.untyped.start..info.untyped.end {
-        if (1 << info.untypedList[idx].sizeBits) >= size_bytes {
-            return Some(i);
-        }
-        idx += 1;
-    }
-    None
-}
-
-const CHILD_STACK_SIZE: usize = 4096;
-static mut CHILD_STACK: *const [u64; CHILD_STACK_SIZE] =
-    &[0; CHILD_STACK_SIZE];
-
-        ",
-        )?;
         self.generate_main()?;
         let asm = match *self.arch {
             Arch::X86 => X86_ASM,
@@ -126,95 +107,18 @@ static mut CHILD_STACK: *const [u64; CHILD_STACK_SIZE] =
         self.writer.write_all(
             b"
 fn main() {
-    let bootinfo = unsafe { &*BOOTINFO };
-    let cspace_cap = seL4_CapInitThreadCNode;
-    let pd_cap = seL4_CapInitThreadVSpace;
-    let tcb_cap = bootinfo.empty.start;
-    let untyped = get_untyped(bootinfo, 1 << seL4_TCBBits).unwrap();
-    let retype_err: seL4_Error = unsafe {
-        seL4_Untyped_Retype(
-            untyped,
-            api_object_seL4_TCBObject.into(),
-            seL4_TCBBits.into(),
-            cspace_cap.into(),
-            cspace_cap.into(),
-            seL4_WordBits.into(),
-            tcb_cap,
-            1,
-        )
-    };
-
-    assert!(retype_err == 0, \"Failed to retype untyped memory\");
-
-    let tcb_err: seL4_Error = unsafe {
-        seL4_TCB_Configure(
-            tcb_cap,
-            seL4_CapNull.into(),
-            cspace_cap.into(),
-            seL4_NilData.into(),
-            pd_cap.into(),
-            seL4_NilData.into(),
-            0,
-            0,
-        )
-    };
-
-    assert!(tcb_err == 0, \"Failed to configure TCB\");
-
-    let stack_base = unsafe { CHILD_STACK as usize };
-    let stack_top = stack_base + CHILD_STACK_SIZE;
-    let mut regs: seL4_UserContext = unsafe { mem::zeroed() };\n",
+    let bootinfo = unsafe { &*BOOTINFO };\n",
         )?;
-
-        match *self.arch {
-            Arch::X86 | Arch::X86_64 => {
-                writeln!(
-                    self.writer,
-                    "    #[cfg(feature = \"test\")]
-    {{ regs.rip = {}::fel4_test::run as seL4_Word; }}
+        writeln!(
+            self.writer,
+            "    #[cfg(feature = \"test\")]
+    {{ {}::fel4_test::run(bootinfo); }}
     #[cfg(not(feature = \"test\"))]
-    {{ regs.rip = {}::run as seL4_Word; }}",
-                    self.package_module_name, self.package_module_name,
-                )?;
-                writeln!(self.writer, "    regs.rsp = stack_top as seL4_Word;")?;
-            }
-            Arch::Armv7 => {
-                writeln!(
-                    self.writer,
-                    "    #[cfg(feature = \"test\")]
-    {{ regs.pc = {}::fel4_test::run as seL4_Word; }}
-    #[cfg(not(feature = \"test\"))]
-    {{ regs.pc = {}::run as seL4_Word; }}",
-                    self.package_module_name, self.package_module_name
-                )?;
-                writeln!(self.writer, "    regs.sp = stack_top as seL4_Word;")?;
-            }
-            Arch::Aarch64 => {
-                writeln!(
-                    self.writer,
-                    "    #[cfg(feature = \"test\")]
-    {{ regs.pc = {}::fel4_test::run as seL4_Word; }}
-    #[cfg(not(feature = \"test\"))]
-    {{ regs.pc = {}::run as seL4_Word; }}",
-                    self.package_module_name, self.package_module_name
-                )?;
-                writeln!(self.writer, "    regs.sp = stack_top as seL4_Word;")?;
-            }
-        }
+    {{ {}::run(bootinfo); }}",
+            self.package_module_name, self.package_module_name,
+        )?;
         self.writer.write_all(
-            b"
-    let _: u32 =
-        unsafe { seL4_TCB_WriteRegisters(tcb_cap, 0, 0, 2, &mut regs) };
-    let _: u32 = unsafe {
-        seL4_TCB_SetPriority(tcb_cap, seL4_CapInitThreadTCB.into(), 255)
-    };
-    let _: u32 = unsafe { seL4_TCB_Resume(tcb_cap) };
-    loop {
-        unsafe {
-            seL4_Yield();
-        }
-    }
-}
+            b"}
         ",
         )?;
         Ok(())

--- a/templates/fel4_test.rs
+++ b/templates/fel4_test.rs
@@ -22,7 +22,7 @@ macro_rules! debug_println {
 }
 
 #[cfg(feature = "KernelPrinting")]
-pub fn run() {
+pub fn run(_bootinfo: &seL4_BootInfo) {
     debug_println!("\n\nrunning example tests");
     let mut runner = TestRunner::default();
     let mut num_passed = 0;

--- a/templates/lib.rs
+++ b/templates/lib.rs
@@ -30,6 +30,6 @@ macro_rules! debug_println {
     ($fmt:expr, $($arg:tt)*) => (debug_print!(concat!($fmt, "\n"), $($arg)*));
 }
 
-pub fn run() {
+pub fn run(_bootinfo: &sel4_sys::seL4_BootInfo) {
     debug_println!("\nhello from a feL4 app!\n");
 }


### PR DESCRIPTION
This includes all of the changes to `cargo-fel4` to get an adaptation of the [seL4 capabilities tutorial](https://docs.sel4.systems/Tutorials/capabilities.html) working.

The tutorial suggests that it is important that we have access to the `seL4_BootInfo` structure from `run()`.

I also have some additions to `libsel4-sys` but failed to compile an unmodified copy of that repository. There's no place to post an issue (GitHub issues is disabled on all related repositories), so I thought I'd mention it here. The error message I get is:

```
running: "cmake" "/mnt/c/Users/user/Documents/Repositories/libsel4-sys/." "-G" "Ninja" "-DCMAKE_TOOLCHAIN_FILE=/home/user/Repositories/libsel4-sys/deps/seL4_kernel/gcc.cmake" "-DKERNEL_PATH=/home/user/Repositories/libsel4-sys/deps/seL4_kernel" "-DKernelFPU=FXSAVE" "-DKernelIRQController=IOAPIC" "-DKernelMultiboot2Header:BOOL=ON" "-DKernelMaxNumNodes=1" "-DLibPlatSupportX86ConsoleDevice=com1" "-DKernelPrinting:BOOL=ON" "-DKernelCacheLnSz=64" "-DKernelNumPriorities=256" "-DKernelMultibootGFXMode=none" "-DKernelXSaveSize=576" "-DKernelX86IBPBOnContextSwitch:BOOL=OFF" "-DKernelResetChunkBits=8" "-DKernelBenchmarks=none" "-DKernelTimerTickMS=2" "-DKernelX86IBRSMode=ibrs_none" "-DKernelFPUMaxRestoresSinceSwitch=64" "-DKernelRootCNodeSizeBits=19" "-DKernelHugePage:BOOL=ON" "-DBuildWithCommonSimulationSettings:BOOL=ON" "-DKernelSupportPCID:BOOL=OFF" "-DKernelIRQReporting:BOOL=ON" "-DKernelLAPICMode=XAPIC" "-DKernelSyscall=syscall" "-DLibSel4FunctionAttributes=public" "-DKernelTimeSlice=5" "-DKernelDebugBuild:BOOL=ON" "-DKernelMaxNumIOAPIC=1" "-DLinkPageSize=4096" "-DHardwareDebugAPI:BOOL=OFF" "-DKernelFastpath:BOOL=ON" "-DKernelMultiboot1Header:BOOL=ON" "-DLibSel4DebugAllocBufferEntries=0" "-DKernelDebugDisablePrefetchers:BOOL=OFF" "-DKernelOptimisation=-O2" "-DKernelX86DangerousMSR:BOOL=OFF" "-DKernelFSGSBase=msr" "-DLibSel4DebugFunctionInstrumentation=none" "-DUserLinkerGCSections:BOOL=OFF" "-DKernelColourPrinting:BOOL=ON" "-DKernelRetypeFanOutLimit=256" "-DKernelArch=x86" "-DKernelX86Sel4Arch=x86_64" "-DKernelVerificationBuild:BOOL=OFF" "-DKernelSkimWindow:BOOL=ON" "-DKernelFWholeProgram:BOOL=OFF" "-DKernelX86MicroArch=nehalem" "-DKernelMaxNumBootinfoUntypedCaps=230" "-DKernelMaxNumWorkUnitsPerPreemption=100" "-DKernelVTX:BOOL=OFF" "-DKernelIOMMU:BOOL=OFF" "-DKernelNumDomains=1" "-DKernelStackBits=12" "-DKernelExportPMCUser:BOOL=OFF" "-DKernelX86RSBOnContextSwitch:BOOL=OFF" "-DKernelUserStackTraceLength=16" "-DCMAKE_C_FLAGS=" "-DCMAKE_CXX_FLAGS=" "-DCMAKE_INSTALL_PREFIX=/mnt/c/Users/user/Documents/Repositories/project/target/x86_64-sel4-fel4/debug/build/libsel4-sys-c3d4bc8dfb80d779/out" "-DCMAKE_BUILD_TYPE=Debug"
-- Configuring incomplete, errors occurred!

--- stderr
CMake Error at /usr/share/cmake-3.10/Modules/CMakeDetermineSystem.cmake:100 (message):
  Could not find toolchain file:
  /home/user/Repositories/libsel4-sys/deps/seL4_kernel/gcc.cmake
Call Stack (most recent call first):
  CMakeLists.txt
```

Thanks in advance!
~mlr